### PR TITLE
verbose sensors joint attachment

### DIFF
--- a/raisimGymTorch/raisimGymTorch/env/envs/rsg_ouzel/Environment.hpp
+++ b/raisimGymTorch/raisimGymTorch/env/envs/rsg_ouzel/Environment.hpp
@@ -5,10 +5,10 @@
 
 #pragma once
 
-#include <stdlib.h>
-#include <set>
-#include <functional>
 #include <algorithm>
+#include <functional>
+#include <set>
+#include <stdlib.h>
 
 #include "../../RaisimGymEnv.hpp"
 #include "include/impedance_control_module.h"
@@ -18,16 +18,18 @@ namespace raisim {
 
 class ENVIRONMENT : public RaisimGymEnv {
 
- public:
-
-  explicit ENVIRONMENT(const std::string& resourceDir, const Yaml::Node& cfg, bool visualizable) :
-      RaisimGymEnv(resourceDir, cfg), visualizable_(visualizable), unifDistPlusMinusOne_(-1.0, 1.0), controller_(cfg["controller"]) {
+public:
+  explicit ENVIRONMENT(const std::string &resourceDir, const Yaml::Node &cfg,
+                       bool visualizable)
+      : RaisimGymEnv(resourceDir, cfg), visualizable_(visualizable),
+        unifDistPlusMinusOne_(-1.0, 1.0), controller_(cfg["controller"]) {
     /// create world
     world_ = std::make_unique<raisim::World>();
-    
-    /// add objects 
+
+    /// add objects
     ouzel_ = world_->addArticulatedSystem(resourceDir_ + "/ouzel/temp.urdf");
-    shelf_ = world_->addArticulatedSystem(resourceDir_ + "/objectInteraction/model.urdf");
+    shelf_ = world_->addArticulatedSystem(resourceDir_ +
+                                          "/objectInteraction/model.urdf");
 
     shelf_->setName("shelf");
     ouzel_->setName("ouzel");
@@ -37,41 +39,51 @@ class ENVIRONMENT : public RaisimGymEnv {
 
     /// get robot data
     gcDim_ = ouzel_->getGeneralizedCoordinateDim(); // -> 25
-    gvDim_ = ouzel_->getDOF(); // -> 24
-    nJoints_ = gvDim_ - 6; // -> 18
+    gvDim_ = ouzel_->getDOF();                      // -> 24
+    nJoints_ = gvDim_ - 6;                          // -> 18
     // std::cout << "gcDim_: " << gcDim_ << std::endl;
     // std::cout << "gvDim_: " << gvDim_ << std::endl;
     // std::cout << "nJoints_: " << nJoints_ << std::endl;
 
     /// get object data
     gcDim_shelf_ = shelf_->getGeneralizedCoordinateDim(); // ->1
-    gvDim_shelf_ = shelf_->getDOF(); // ->1
+    gvDim_shelf_ = shelf_->getDOF();                      // ->1
     nJoints_shelf_ = 1;
 
-
     /// initialize containers
-    gc_.setZero(gcDim_); gc_init_.setZero(gcDim_);
-    gv_.setZero(gvDim_); gv_init_.setZero(gvDim_);
-    
-    gc_shelf_.setZero(gcDim_shelf_); gc_init_shelf_.setZero(gcDim_shelf_);
-    gv_shelf_.setZero(gvDim_shelf_); gv_init_shelf_.setZero(gvDim_shelf_); 
+    gc_.setZero(gcDim_);
+    gc_init_.setZero(gcDim_);
+    gv_.setZero(gvDim_);
+    gv_init_.setZero(gvDim_);
 
-//    pTarget_.setZero(gcDim_); vTarget_.setZero(gvDim_); pTarget12_.setZero(nJoints_);
+    gc_shelf_.setZero(gcDim_shelf_);
+    gc_init_shelf_.setZero(gcDim_shelf_);
+    gv_shelf_.setZero(gvDim_shelf_);
+    gv_init_shelf_.setZero(gvDim_shelf_);
+
+    //    pTarget_.setZero(gcDim_); vTarget_.setZero(gvDim_);
+    //    pTarget12_.setZero(nJoints_);
     control_dt_ = cfg["control_dt"].template As<float>();
     simulation_dt_ = cfg["simulation_dt"].template As<float>();
 
     /// Initialisation Parameters
-    initialDistanceOffset_ = cfg["initialisation"]["distanceOffset"].template As<float>();
-    initialAngularOffset_ = cfg["initialisation"]["angleOffsetDeg"].template As<float>() / 180.0 * M_PI;
+    initialDistanceOffset_ =
+        cfg["initialisation"]["distanceOffset"].template As<float>();
+    initialAngularOffset_ =
+        cfg["initialisation"]["angleOffsetDeg"].template As<float>() / 180.0 *
+        M_PI;
     initialLinearVel_ = cfg["initialisation"]["linearVel"].template As<float>();
-    initialAngularVel_ = cfg["initialisation"]["angularVelDeg"].template As<float>() / 180.0 * M_PI;
+    initialAngularVel_ =
+        cfg["initialisation"]["angularVelDeg"].template As<float>() / 180.0 *
+        M_PI;
 
     resetInitialConditions();
 
     /// MUST BE DONE FOR ALL ENVIRONMENTS
     obDim_ = 27; // ^^ to change after observe()
-    actionDim_ =  9;
-    actionMean_.setZero(actionDim_); actionStd_.setZero(actionDim_);
+    actionDim_ = 9;
+    actionMean_.setZero(actionDim_);
+    actionStd_.setZero(actionDim_);
     position_W_.setZero();
     orientation_W_B_.setIdentity();
     bodyLinearVel_.setZero();
@@ -82,32 +94,46 @@ class ENVIRONMENT : public RaisimGymEnv {
     actionStd_.setConstant(0.3);
 
     /// Reward coefficients
-    rewards_.initializeFromConfigurationFile (cfg["reward"]);
-    terminalOOBRewardCoeff_ = cfg["termination"]["oob"]["reward"].template As<float>();
-    terminalOOBWaypointDist_ = cfg["termination"]["oob"]["waypointDist"].template As<float>();
-    terminalOOBAngleError_ = cfg["termination"]["oob"]["angleErrorDeg"].template As<float>() / 180.0 * M_PI;
-    terminalSuccessRewardCoeff_ = cfg["termination"]["success"]["reward"].template As<float>();
-    terminalSuccessWaypointDist_ = cfg["termination"]["success"]["waypointDist"].template As<float>();
-    terminalSuccessAngleError_ = cfg["termination"]["success"]["angleErrorDeg"].template As<float>() / 180.0 * M_PI;
-    terminalSuccessLinearVel_ = cfg["termination"]["success"]["linearVel"].template As<float>();
-    terminalSuccessAngularVel_ = cfg["termination"]["success"]["angularVelDeg"].template As<float>() / 180.0 * M_PI;
+    rewards_.initializeFromConfigurationFile(cfg["reward"]);
+    terminalOOBRewardCoeff_ =
+        cfg["termination"]["oob"]["reward"].template As<float>();
+    terminalOOBWaypointDist_ =
+        cfg["termination"]["oob"]["waypointDist"].template As<float>();
+    terminalOOBAngleError_ =
+        cfg["termination"]["oob"]["angleErrorDeg"].template As<float>() /
+        180.0 * M_PI;
+    terminalSuccessRewardCoeff_ =
+        cfg["termination"]["success"]["reward"].template As<float>();
+    terminalSuccessWaypointDist_ =
+        cfg["termination"]["success"]["waypointDist"].template As<float>();
+    terminalSuccessAngleError_ =
+        cfg["termination"]["success"]["angleErrorDeg"].template As<float>() /
+        180.0 * M_PI;
+    terminalSuccessLinearVel_ =
+        cfg["termination"]["success"]["linearVel"].template As<float>();
+    terminalSuccessAngularVel_ =
+        cfg["termination"]["success"]["angularVelDeg"].template As<float>() /
+        180.0 * M_PI;
 
     // Add sensors
-    auto* odometry_noise = new raisim_sensors::odometryNoise(control_dt_, cfg["odometryNoise"]);
-    odometry_ = raisim_sensors::odometry(ouzel_, control_dt_, "ouzel", "ouzel/base_link", odometry_noise);
-    // odometry(raisim::ArticulatedSystem *robot, double sampleTime, const std::string child_frame_name, const std::string sensor_link_name , noise<Eigen::VectorXd> * noise_source = NULL)
-    odometry_shelf_ = raisim_sensors::odometry(shelf_, control_dt_, "shelf", "measured_joint_link", odometry_noise);
-    
-    
-    // to add: odometry_handle_link 
+    auto *odometry_noise =
+        new raisim_sensors::odometryNoise(control_dt_, cfg["odometryNoise"]);
+    odometry_ = raisim_sensors::odometry(ouzel_, control_dt_, "ouzel",
+                                         "ouzel/base_link", odometry_noise);
+    // odometry(raisim::ArticulatedSystem *robot, double sampleTime, const
+    // std::string child_frame_name, const std::string sensor_link_name ,
+    // noise<Eigen::VectorXd> * noise_source = NULL)
+    odometry_shelf_ =
+        raisim_sensors::odometry(shelf_, control_dt_, "shelf",
+                                 "measured_test_handle_joint", odometry_noise);
 
-    
+    // to add: odometry_handle_link
 
     /// indices of links that should not make contact with ground -> no ground
-//    footIndices_.insert(anymal_->getBodyIdx("LF_SHANK"));
-//    footIndices_.insert(anymal_->getBodyIdx("RF_SHANK"));
-//    footIndices_.insert(anymal_->getBodyIdx("LH_SHANK"));
-//    footIndices_.insert(anymal_->getBodyIdx("RH_SHANK"));
+    //    footIndices_.insert(anymal_->getBodyIdx("LF_SHANK"));
+    //    footIndices_.insert(anymal_->getBodyIdx("RF_SHANK"));
+    //    footIndices_.insert(anymal_->getBodyIdx("LH_SHANK"));
+    //    footIndices_.insert(anymal_->getBodyIdx("RH_SHANK"));
 
     /// visualize if it is the first environment
     if (visualizable_) {
@@ -115,111 +141,136 @@ class ENVIRONMENT : public RaisimGymEnv {
       server_->launchServer();
       server_->focusOn(ouzel_);
     }
-//    auto mass_vector = ouzel_->getMass();
-//    auto com_W_vector = ouzel_->getBodyCOM_W();
-//    auto inertia_B_vector = ouzel_->getInertia();
-//    double total_mass = 0;
-//    raisim::Vec<3> com_W = Eigen::Vector3d::Zero();
-//    raisim::Vec<3> inertia_W = Eigen::Vector3d::Zero();
-//    raisim::Vec<3> pos_W;
-//    raisim::Vec<3> pos_body_W;
-//    raisim::Vec<3> pos_body_W_squared;
-//    for (int i = 0; i < mass_vector.size(); i++) {
-//      total_mass += mass_vector[i];
-//      com_W += com_W_vector[i] * mass_vector[i];
-//      ouzel_->getPosition(i, pos_body_W);
-//      pos_body_W -= ouzel_->getCOM();
-//    }
-//    com_W = com_W / total_mass;
-//    ouzel_->getPosition(0, pos_W);
-//    raisim::Vec<3> com_offset = com_W - pos_W;
-//    auto a = ouzel_->getCompositeCOM();
-//    auto b = ouzel_->getInertia();
-//    std::cout << "ouzel mass: " << ouzel_->getCompositeMass()[0] << std::endl;
-//    std::cout << "ouzel com W: " << ouzel_->getCOM() << std::endl;
-//    std::cout << "ouzel com_offset: " <<com_offset<< std::endl;
-//    std::cout << "ouzel inertia: " << ouzel_->getMassMatrix() << std::endl;
-//    std::cout << "ouzel inertia: " << ouzel_->getMassMatrix().size() << std::endl;
-//
-//    int baseLink_ = ouzel_->getBodyIdx("ouzel/base_link");
-//    raisim::Vec<3> com_pos = ouzel_->getCOM();
-//    const std::vector<std::string> bodyList = ouzel_->getBodyNames();
-//    raisim::Vec<3> base_link_pos_W;
-//    ouzel_->getFramePosition(baseLink_, base_link_pos_W);
-//    double Ixx=0, Iyy=0, Izz=0;
-//    for (std::string bodyName : bodyList) {
-//      size_t bodyIdx;
-//      bodyIdx = ouzel_->getBodyIdx(bodyName);
-//      raisim::Vec<3> point_W;
-//      ouzel_->getFramePosition(bodyIdx, point_W);
-//      double dx = point_W(0) - com_pos(0);
-//      double dy = point_W(1) - com_pos(1);
-//      double dz = point_W(2) - com_pos(2);
-//      Ixx += (dy*dy + dz*dz)*ouzel_->getMass(bodyIdx);
-//      Iyy += (dx*dx + dz*dz)*ouzel_->getMass(bodyIdx);
-//      Izz += (dy*dy + dx*dx)*ouzel_->getMass(bodyIdx);
-//    }
-//
-//    std::cout << "Inertia diagonal w.r.t. COM: "<<Ixx<<" "<<Iyy<<" "<<Izz << std::endl;
-//    std::cout << "ouzel inertia: " << ouzel_->getCompositeInertia().back()<< std::endl;
+    //    auto mass_vector = ouzel_->getMass();
+    //    auto com_W_vector = ouzel_->getBodyCOM_W();
+    //    auto inertia_B_vector = ouzel_->getInertia();
+    //    double total_mass = 0;
+    //    raisim::Vec<3> com_W = Eigen::Vector3d::Zero();
+    //    raisim::Vec<3> inertia_W = Eigen::Vector3d::Zero();
+    //    raisim::Vec<3> pos_W;
+    //    raisim::Vec<3> pos_body_W;
+    //    raisim::Vec<3> pos_body_W_squared;
+    //    for (int i = 0; i < mass_vector.size(); i++) {
+    //      total_mass += mass_vector[i];
+    //      com_W += com_W_vector[i] * mass_vector[i];
+    //      ouzel_->getPosition(i, pos_body_W);
+    //      pos_body_W -= ouzel_->getCOM();
+    //    }
+    //    com_W = com_W / total_mass;
+    //    ouzel_->getPosition(0, pos_W);
+    //    raisim::Vec<3> com_offset = com_W - pos_W;
+    //    auto a = ouzel_->getCompositeCOM();
+    //    auto b = ouzel_->getInertia();
+    //    std::cout << "ouzel mass: " << ouzel_->getCompositeMass()[0] <<
+    //    std::endl; std::cout << "ouzel com W: " << ouzel_->getCOM() <<
+    //    std::endl; std::cout << "ouzel com_offset: " <<com_offset<< std::endl;
+    //    std::cout << "ouzel inertia: " << ouzel_->getMassMatrix() <<
+    //    std::endl; std::cout << "ouzel inertia: " <<
+    //    ouzel_->getMassMatrix().size() << std::endl;
+    //
+    //    int baseLink_ = ouzel_->getBodyIdx("ouzel/base_link");
+    //    raisim::Vec<3> com_pos = ouzel_->getCOM();
+    //    const std::vector<std::string> bodyList = ouzel_->getBodyNames();
+    //    raisim::Vec<3> base_link_pos_W;
+    //    ouzel_->getFramePosition(baseLink_, base_link_pos_W);
+    //    double Ixx=0, Iyy=0, Izz=0;
+    //    for (std::string bodyName : bodyList) {
+    //      size_t bodyIdx;
+    //      bodyIdx = ouzel_->getBodyIdx(bodyName);
+    //      raisim::Vec<3> point_W;
+    //      ouzel_->getFramePosition(bodyIdx, point_W);
+    //      double dx = point_W(0) - com_pos(0);
+    //      double dy = point_W(1) - com_pos(1);
+    //      double dz = point_W(2) - com_pos(2);
+    //      Ixx += (dy*dy + dz*dz)*ouzel_->getMass(bodyIdx);
+    //      Iyy += (dx*dx + dz*dz)*ouzel_->getMass(bodyIdx);
+    //      Izz += (dy*dy + dx*dx)*ouzel_->getMass(bodyIdx);
+    //    }
+    //
+    //    std::cout << "Inertia diagonal w.r.t. COM: "<<Ixx<<" "<<Iyy<<" "<<Izz
+    //    << std::endl; std::cout << "ouzel inertia: " <<
+    //    ouzel_->getCompositeInertia().back()<< std::endl;
   }
 
-  void init() final { }
+  void init() final {}
 
   void reset() final {
     resetInitialConditions();
     ouzel_->setState(gc_init_, gv_init_);
     updateObservation();
-//    auto base_link_idx = ouzel_->getBodyIdx("ouzel/base_link");
-//    raisim::Vec<3> base_link_pos_W;
-//    ouzel_->getFramePosition(base_link_idx, base_link_pos_W);
-//    std::cout << "none" << std::endl;
+    //    auto base_link_idx = ouzel_->getBodyIdx("ouzel/base_link");
+    //    raisim::Vec<3> base_link_pos_W;
+    //    ouzel_->getFramePosition(base_link_idx, base_link_pos_W);
+    //    std::cout << "none" << std::endl;
   }
 
-  float step(const Eigen::Ref<EigenVec>& action) final {
+  float step(const Eigen::Ref<EigenVec> &action) final {
     // give adapted waypoint to controller -> get wrench
-//    std::cout << "action: " << action << std::endl;
-//    controller_.setOdom(position_W_gt_, orientation_W_B_gt_, bodyLinearVel_gt_, bodyAngularVel_gt_);
-    controller_.setOdom(position_W_, orientation_W_B_, bodyLinearVel_, bodyAngularVel_);
+    //    std::cout << "action: " << action << std::endl;
+    //    controller_.setOdom(position_W_gt_, orientation_W_B_gt_,
+    //    bodyLinearVel_gt_, bodyAngularVel_gt_);
+    controller_.setOdom(position_W_, orientation_W_B_, bodyLinearVel_,
+                        bodyAngularVel_);
 
-//    std::cout << "ref pos: " << ref_position_ << std::endl;
-//    std::cout << "ref orient coeffs: " << ref_orientation_.coeffs() << std::endl;
-//    double waypoint_distw, error_anglew;
-//    computeErrorMetrics(waypoint_distw, error_anglew);
-//    std::cout << "waypoint dist before action: " << waypoint_distw << std::endl;
-//    std::cout << "angle error deg before action: " << error_anglew / M_PI * 180 << std::endl;
+    //    std::cout << "ref pos: " << ref_position_ << std::endl;
+    //    std::cout << "ref orient coeffs: " << ref_orientation_.coeffs() <<
+    //    std::endl; double waypoint_distw, error_anglew;
+    //    computeErrorMetrics(waypoint_distw, error_anglew);
+    //    std::cout << "waypoint dist before action: " << waypoint_distw <<
+    //    std::endl; std::cout << "angle error deg before action: " <<
+    //    error_anglew / M_PI * 180 << std::endl;
 
     auto actionD = action.cast<double>();
     Eigen::Vector3d ref_position_corr_vec = actionD.segment(0, 3);
-    Eigen::Quaterniond ref_orientation_corr = QuaternionFromTwoVectors(actionD.segment(3, 3), actionD.segment(6, 3));
-//    std::cout << "action ref pos: " << ref_position_corr_vec << std::endl;
-//    std::cout << "action ref orient coeffs: " << ref_orientation_corr.coeffs() << std::endl;
+    Eigen::Quaterniond ref_orientation_corr =
+        QuaternionFromTwoVectors(actionD.segment(3, 3), actionD.segment(6, 3));
+    //    std::cout << "action ref pos: " << ref_position_corr_vec << std::endl;
+    //    std::cout << "action ref orient coeffs: " <<
+    //    ref_orientation_corr.coeffs() << std::endl;
     controller_.setRefFromAction(ref_position_corr_vec, ref_orientation_corr);
 
     mav_msgs::EigenTorqueThrust wrench_command;
     controller_.calculateWrenchCommand(&wrench_command, control_dt_);
-//    std::cout << "commanded thrust:\n" << wrench_command.thrust << "\n" << "commanded torque:\n" << wrench_command.torque << std::endl;
+    //    std::cout << "commanded thrust:\n" << wrench_command.thrust << "\n" <<
+    //    "commanded torque:\n" << wrench_command.torque << std::endl;
 
-//    std::cout << "base link idx: " << ouzel_->getBodyIdx("ouzel/base_link") << std::endl;
+    //    std::cout << "base link idx: " <<
+    //    ouzel_->getBodyIdx("ouzel/base_link") << std::endl;
     Vec<3> orig;
     orig.setZero();
-//    Eigen::Vector3d levitation_force_W(0, 0, ouzel_->getTotalMass() * 9.81);
-//    Eigen::Vector3d levitation_force_B = orientation_W_B_gt_.inverse().toRotationMatrix() * levitation_force_W;
-//    Eigen::Vector3d test_torque_W(0, 0, 0.1);
-//    Eigen::Vector3d test_torque_B = orientation_W_B_gt_.inverse().toRotationMatrix() * test_torque_W;
-    for(int i=0; i< int(control_dt_ / simulation_dt_ + 1e-10); i++){
+    //    Eigen::Vector3d levitation_force_W(0, 0, ouzel_->getTotalMass()
+    //    * 9.81); Eigen::Vector3d levitation_force_B =
+    //    orientation_W_B_gt_.inverse().toRotationMatrix() * levitation_force_W;
+    //    Eigen::Vector3d test_torque_W(0, 0, 0.1);
+    //    Eigen::Vector3d test_torque_B =
+    //    orientation_W_B_gt_.inverse().toRotationMatrix() * test_torque_W;
+    for (int i = 0; i < int(control_dt_ / simulation_dt_ + 1e-10); i++) {
       // apply wrench on ouzel
-      ouzel_->setExternalForce(ouzel_->getBodyIdx("ouzel/base_link"), ouzel_->BODY_FRAME, wrench_command.thrust, ouzel_->WORLD_FRAME, ouzel_->getCOM()); // set force in body frame
-      ouzel_->setExternalTorqueInBodyFrame(ouzel_->getBodyIdx("ouzel/base_link"), wrench_command.torque);
-//      ouzel_->setExternalForce(ouzel_->getBodyIdx("ouzel/base_link"), ouzel_->BODY_FRAME, wrench_command.thrust, ouzel_->BODY_FRAME, orig); // set force in body frame
-//      ouzel_->setExternalForce(ouzel_->getBodyIdx("ouzel/base_link"), ouzel_->WORLD_FRAME, levitation_force_W, ouzel_->WORLD_FRAME, ouzel_->getCOM()); // set force in body frame
-//      ouzel_->setExternalForce(ouzel_->getBodyIdx("ouzel/base_link"), ouzel_->BODY_FRAME, levitation_force_B, ouzel_->WORLD_FRAME, ouzel_->getCOM()); // set force in body frame
-//      ouzel_->setExternalTorqueInBodyFrame(ouzel_->getBodyIdx("ouzel/base_link"), test_torque_B);
-//      ouzel_->setExternalTorqueInBodyFrame(ouzel_->getBodyIdx("ouzel/base_link"), wrench_command.torque);
+      ouzel_->setExternalForce(ouzel_->getBodyIdx("ouzel/base_link"),
+                               ouzel_->BODY_FRAME, wrench_command.thrust,
+                               ouzel_->WORLD_FRAME,
+                               ouzel_->getCOM()); // set force in body frame
+      ouzel_->setExternalTorqueInBodyFrame(
+          ouzel_->getBodyIdx("ouzel/base_link"), wrench_command.torque);
+      //      ouzel_->setExternalForce(ouzel_->getBodyIdx("ouzel/base_link"),
+      //      ouzel_->BODY_FRAME, wrench_command.thrust, ouzel_->BODY_FRAME,
+      //      orig); // set force in body frame
+      //      ouzel_->setExternalForce(ouzel_->getBodyIdx("ouzel/base_link"),
+      //      ouzel_->WORLD_FRAME, levitation_force_W, ouzel_->WORLD_FRAME,
+      //      ouzel_->getCOM()); // set force in body frame
+      //      ouzel_->setExternalForce(ouzel_->getBodyIdx("ouzel/base_link"),
+      //      ouzel_->BODY_FRAME, levitation_force_B, ouzel_->WORLD_FRAME,
+      //      ouzel_->getCOM()); // set force in body frame
+      //      ouzel_->setExternalTorqueInBodyFrame(ouzel_->getBodyIdx("ouzel/base_link"),
+      //      test_torque_B);
+      //      ouzel_->setExternalTorqueInBodyFrame(ouzel_->getBodyIdx("ouzel/base_link"),
+      //      wrench_command.torque);
 
-      if(server_) server_->lockVisualizationServerMutex();
+      if (server_)
+        server_->lockVisualizationServerMutex();
       world_->integrate();
-      if(server_) server_->unlockVisualizationServerMutex();
+      if (server_)
+        server_->unlockVisualizationServerMutex();
     }
 
     // get observations
@@ -228,33 +279,45 @@ class ENVIRONMENT : public RaisimGymEnv {
     double waypoint_dist, error_angle;
     computeErrorMetrics(waypoint_dist, error_angle);
     Eigen::AngleAxisd ref_orientation_corr_angle_axis(ref_orientation_corr);
-//    std::cout << "waypoint dist: " << waypoint_dist << std::endl;
-//    std::cout << "angle error deg: " << error_angle / M_PI * 180 << std::endl;
-//    std::cout << "angle error: " << error_angle << std::endl;
-//    std::cout << "ref orient corr angle: " << float(ref_orientation_corr_angle_axis.angle()) << std::endl;
+    //    std::cout << "waypoint dist: " << waypoint_dist << std::endl;
+    //    std::cout << "angle error deg: " << error_angle / M_PI * 180 <<
+    //    std::endl; std::cout << "angle error: " << error_angle << std::endl;
+    //    std::cout << "ref orient corr angle: " <<
+    //    float(ref_orientation_corr_angle_axis.angle()) << std::endl;
     rewards_.record("waypointDist", float(waypoint_dist));
     rewards_.record("orientError", float(error_angle));
-    rewards_.record("linearRefCorr", float(ref_position_corr_vec.squaredNorm()));
-    rewards_.record("orientRefCorr", float(ref_orientation_corr_angle_axis.angle()));
-//    rewards_.record("angularVel", anymal_->getGeneralizedForce().squaredNorm());
-//    rewards_.record("force", anymal_->getGeneralizedForce().squaredNorm());
-//    rewards_.record("torque", anymal_->getGeneralizedForce().squaredNorm());
+    rewards_.record("linearRefCorr",
+                    float(ref_position_corr_vec.squaredNorm()));
+    rewards_.record("orientRefCorr",
+                    float(ref_orientation_corr_angle_axis.angle()));
+    //    rewards_.record("angularVel",
+    //    anymal_->getGeneralizedForce().squaredNorm());
+    //    rewards_.record("force",
+    //    anymal_->getGeneralizedForce().squaredNorm());
+    //    rewards_.record("torque",
+    //    anymal_->getGeneralizedForce().squaredNorm());
 
     return rewards_.sum();
   }
 
-  
   void updateObservation() {
     odometry_.update();
     Eigen::VectorXd odometry_measurement = odometry_.getMeas();
     position_W_ = odometry_measurement.segment(0, 3);
-    orientation_W_B_ = Eigen::Quaterniond(odometry_measurement(3), odometry_measurement(4), odometry_measurement(5), odometry_measurement(6)).normalized();
+    orientation_W_B_ =
+        Eigen::Quaterniond(odometry_measurement(3), odometry_measurement(4),
+                           odometry_measurement(5), odometry_measurement(6))
+            .normalized();
     bodyLinearVel_ = odometry_measurement.segment(7, 3);
     bodyAngularVel_ = odometry_measurement.segment(10, 3);
 
     Eigen::VectorXd odometry_measurement_gt = odometry_.getMeasGT();
     position_W_gt_ = odometry_measurement_gt.segment(0, 3);
-    orientation_W_B_gt_ = Eigen::Quaterniond(odometry_measurement_gt(3), odometry_measurement_gt(4), odometry_measurement_gt(5), odometry_measurement_gt(6)).normalized();
+    orientation_W_B_gt_ = Eigen::Quaterniond(odometry_measurement_gt(3),
+                                             odometry_measurement_gt(4),
+                                             odometry_measurement_gt(5),
+                                             odometry_measurement_gt(6))
+                              .normalized();
     bodyLinearVel_gt_ = odometry_measurement_gt.segment(7, 3);
     bodyAngularVel_gt_ = odometry_measurement_gt.segment(10, 3);
 
@@ -263,28 +326,38 @@ class ENVIRONMENT : public RaisimGymEnv {
     odometry_shelf_.update();
     Eigen::VectorXd odometry_measurement_shelf = odometry_shelf_.getMeas();
     position_W_shelf_ = odometry_measurement_shelf.segment(0, 3);
-    orientation_W_B_shelf_ = Eigen::Quaterniond(odometry_measurement_shelf(3), odometry_measurement_shelf(4), odometry_measurement_shelf(5), odometry_measurement_shelf(6)).normalized();
+    orientation_W_B_shelf_ = Eigen::Quaterniond(odometry_measurement_shelf(3),
+                                                odometry_measurement_shelf(4),
+                                                odometry_measurement_shelf(5),
+                                                odometry_measurement_shelf(6))
+                                 .normalized();
     bodyLinearVel_shelf_ = odometry_measurement_shelf.segment(7, 3);
     bodyAngularVel_shelf_ = odometry_measurement_shelf.segment(10, 3);
-    
-    // std::cout << "position_W_shelf_: " << position_W_shelf_ << std::endl;
+
+    std::cout << "position_W_shelf_: " << position_W_shelf_ << std::endl;
 
     Eigen::VectorXd odometry_measurement_shelf_gt = odometry_.getMeasGT();
     position_W_shelf_gt_ = odometry_measurement_shelf_gt.segment(0, 3);
-    orientation_W_B_shelf_gt_ = Eigen::Quaterniond(odometry_measurement_shelf_gt(3), odometry_measurement_shelf_gt(4), odometry_measurement_shelf_gt(5), odometry_measurement_shelf_gt(6)).normalized();
+    orientation_W_B_shelf_gt_ =
+        Eigen::Quaterniond(
+            odometry_measurement_shelf_gt(3), odometry_measurement_shelf_gt(4),
+            odometry_measurement_shelf_gt(5), odometry_measurement_shelf_gt(6))
+            .normalized();
     bodyLinearVel_shelf_gt_ = odometry_measurement_shelf_gt.segment(7, 3);
     bodyAngularVel_shelf_gt_ = odometry_measurement_shelf_gt.segment(10, 3);
 
     shelf_->getState(gc_shelf_, gv_shelf_);
 
-//    std::cout << "odometry_measurement: " << odometry_measurement.size() << std::endl;
-//    std::cout << "position W: " << position_W_ << std::endl;
-//    std::cout << "orientation_W_B_ coeffs: " << orientation_W_B_.coeffs() << std::endl;
-//    std::cout << "bodyLinearVel_: " << bodyLinearVel_ << std::endl;
-//    std::cout << "bodyAngularVel_: " << bodyAngularVel_ << std::endl;
+    //    std::cout << "odometry_measurement: " << odometry_measurement.size()
+    //    << std::endl; std::cout << "position W: " << position_W_ << std::endl;
+    //    std::cout << "orientation_W_B_ coeffs: " << orientation_W_B_.coeffs()
+    //    << std::endl; std::cout << "bodyLinearVel_: " << bodyLinearVel_ <<
+    //    std::endl; std::cout << "bodyAngularVel_: " << bodyAngularVel_ <<
+    //    std::endl;
 
-//    Eigen::VectorXd odometry_measurement_gt = odometry_.getMeasGT();
-//    std::cout << "odometry_measurement gt: " << odometry_measurement_gt << std::endl;
+    //    Eigen::VectorXd odometry_measurement_gt = odometry_.getMeasGT();
+    //    std::cout << "odometry_measurement gt: " << odometry_measurement_gt <<
+    //    std::endl;
 
     if (!Eigen::isfinite(gc_.array()).all()) {
       std::cout << "ob is nan!!" << std::endl;
@@ -297,127 +370,162 @@ class ENVIRONMENT : public RaisimGymEnv {
 
   void observe(Eigen::Ref<EigenVec> ob) final {
     /// convert it to float
-    Eigen::Vector3d position_RC_W = position_W_ - ref_position_; // RC for ref to current (size=3)
-    Eigen::Matrix3d orientation_W_B_mat = orientation_W_B_.toRotationMatrix(); // (size=9)
-    Eigen::Matrix3d ref_orientation_mat = ref_orientation_.toRotationMatrix(); // (size=9)
+    Eigen::Vector3d position_RC_W =
+        position_W_ - ref_position_; // RC for ref to current (size=3)
+    Eigen::Matrix3d orientation_W_B_mat =
+        orientation_W_B_.toRotationMatrix(); // (size=9)
+    Eigen::Matrix3d ref_orientation_mat =
+        ref_orientation_.toRotationMatrix(); // (size=9)
     Eigen::VectorXd ob_double(obDim_);
-    ob_double << position_RC_W, orientation_W_B_mat.col(0), orientation_W_B_mat.col(1), orientation_W_B_mat.col(2),
-                 bodyLinearVel_, bodyAngularVel_,
-                 ref_orientation_mat.col(0), ref_orientation_mat.col(1), ref_orientation_mat.col(2);
+    ob_double << position_RC_W, orientation_W_B_mat.col(0),
+        orientation_W_B_mat.col(1), orientation_W_B_mat.col(2), bodyLinearVel_,
+        bodyAngularVel_, ref_orientation_mat.col(0), ref_orientation_mat.col(1),
+        ref_orientation_mat.col(2);
     ob = ob_double.cast<float>(); // size=27
   }
 
-  bool isTerminalState(float& terminalReward) final {
+  bool isTerminalState(float &terminalReward) final {
     double waypoint_dist, error_angle;
     computeErrorMetrics(waypoint_dist, error_angle);
     Eigen::VectorXd odometry_measurement_gt = odometry_.getMeasGT();
     Eigen::Vector3d lin_vel_gt = odometry_measurement_gt.segment(7, 3);
     Eigen::Vector3d ang_vel_gt = odometry_measurement_gt.segment(10, 3);
 
-    if(waypoint_dist > terminalOOBWaypointDist_ || error_angle > terminalOOBAngleError_) {
+    if (waypoint_dist > terminalOOBWaypointDist_ ||
+        error_angle > terminalOOBAngleError_) {
       terminalReward = terminalOOBRewardCoeff_;
-//      std::cout << "termination oob" << std::endl;
+      //      std::cout << "termination oob" << std::endl;
       return true;
-    }
-    else if (waypoint_dist < terminalSuccessWaypointDist_ && error_angle < terminalSuccessAngleError_
-             && lin_vel_gt.norm() < terminalSuccessLinearVel_ && ang_vel_gt.norm() < terminalSuccessAngularVel_) {
+    } else if (waypoint_dist < terminalSuccessWaypointDist_ &&
+               error_angle < terminalSuccessAngleError_ &&
+               lin_vel_gt.norm() < terminalSuccessLinearVel_ &&
+               ang_vel_gt.norm() < terminalSuccessAngularVel_) {
       terminalReward = terminalSuccessRewardCoeff_;
-//      std::cout << "termination success" << std::endl;
+      //      std::cout << "termination success" << std::endl;
       return true;
-    }
-    else {
+    } else {
       terminalReward = 0.f;
       return false;
     }
   }
 
-  void curriculumUpdate() { };
+  void curriculumUpdate(){};
 
-  void setSeed(int seed) {
-    gen_.seed(seed);
-  }
+  void setSeed(int seed) { gen_.seed(seed); }
 
- private:
+private:
   void resetInitialConditions() {
-    // we could set the init position at the door ^^ 
-    if(onlyInteraction){ // change initial condition to offset s.t. hook grasp the hinge !!
-      Eigen::Vector3d init_position(unifDistPlusMinusOne_(gen_), unifDistPlusMinusOne_(gen_), unifDistPlusMinusOne_(gen_));
+    // we could set the init position at the door ^^
+    if (onlyInteraction) { // change initial condition to offset s.t. hook grasp
+                           // the hinge !!
+      Eigen::Vector3d init_position(unifDistPlusMinusOne_(gen_),
+                                    unifDistPlusMinusOne_(gen_),
+                                    unifDistPlusMinusOne_(gen_));
       position_W_ = init_position;
-    } else{
-      Eigen::Vector3d init_position(unifDistPlusMinusOne_(gen_), unifDistPlusMinusOne_(gen_), unifDistPlusMinusOne_(gen_));
-      position_W_ = init_position;  
+    } else {
+      Eigen::Vector3d init_position(unifDistPlusMinusOne_(gen_),
+                                    unifDistPlusMinusOne_(gen_),
+                                    unifDistPlusMinusOne_(gen_));
+      position_W_ = init_position;
     }
 
-    if(onlyInteraction){
-      Eigen::Vector3d init_orientation(unifDistPlusMinusOne_(gen_), unifDistPlusMinusOne_(gen_), unifDistPlusMinusOne_(gen_));
+    if (onlyInteraction) {
+      Eigen::Vector3d init_orientation(unifDistPlusMinusOne_(gen_),
+                                       unifDistPlusMinusOne_(gen_),
+                                       unifDistPlusMinusOne_(gen_));
       init_orientation.normalize();
       double init_angle = unifDistPlusMinusOne_(gen_) * M_PI;
-      Eigen::Quaterniond init_quaternion(Eigen::AngleAxisd(init_angle, init_orientation));
+      Eigen::Quaterniond init_quaternion(
+          Eigen::AngleAxisd(init_angle, init_orientation));
       init_quaternion.normalize();
       // init_quaternion = Eigen::Quaterniond::Identity();
       orientation_W_B_ = init_quaternion;
     }
 
-    
-
-    Eigen::Vector3d init_lin_vel_dir(unifDistPlusMinusOne_(gen_), unifDistPlusMinusOne_(gen_), unifDistPlusMinusOne_(gen_));
-    Eigen::Vector3d init_lin_vel = init_lin_vel_dir.normalized() * initialLinearVel_ * unifDistPlusMinusOne_(gen_);
+    Eigen::Vector3d init_lin_vel_dir(unifDistPlusMinusOne_(gen_),
+                                     unifDistPlusMinusOne_(gen_),
+                                     unifDistPlusMinusOne_(gen_));
+    Eigen::Vector3d init_lin_vel = init_lin_vel_dir.normalized() *
+                                   initialLinearVel_ *
+                                   unifDistPlusMinusOne_(gen_);
     bodyLinearVel_ = init_lin_vel;
-    Eigen::Vector3d init_lin_vel_W = orientation_W_B_.toRotationMatrix() * init_lin_vel;
-//    std::cout << "init_lin_vel_W: " << init_lin_vel_W << std::endl;
+    Eigen::Vector3d init_lin_vel_W =
+        orientation_W_B_.toRotationMatrix() * init_lin_vel;
+    //    std::cout << "init_lin_vel_W: " << init_lin_vel_W << std::endl;
 
-    Eigen::Vector3d init_ang_vel_axis(unifDistPlusMinusOne_(gen_), unifDistPlusMinusOne_(gen_), unifDistPlusMinusOne_(gen_));
-    Eigen::Vector3d init_ang_vel = init_ang_vel_axis.normalized() * initialAngularVel_ * unifDistPlusMinusOne_(gen_);
+    Eigen::Vector3d init_ang_vel_axis(unifDistPlusMinusOne_(gen_),
+                                      unifDistPlusMinusOne_(gen_),
+                                      unifDistPlusMinusOne_(gen_));
+    Eigen::Vector3d init_ang_vel = init_ang_vel_axis.normalized() *
+                                   initialAngularVel_ *
+                                   unifDistPlusMinusOne_(gen_);
     bodyAngularVel_ = init_ang_vel;
-    Eigen::Vector3d init_ang_vel_W = orientation_W_B_.toRotationMatrix() * init_ang_vel;
-//    std::cout << "init_ang_vel_W: " << init_ang_vel_W << std::endl;
+    Eigen::Vector3d init_ang_vel_W =
+        orientation_W_B_.toRotationMatrix() * init_ang_vel;
+    //    std::cout << "init_ang_vel_W: " << init_ang_vel_W << std::endl;
 
     gc_init_ << position_W_.x(), position_W_.y(), position_W_.z(), // position
-            orientation_W_B_.w(), orientation_W_B_.x(), orientation_W_B_.y(), orientation_W_B_.z(), //orientation quaternion
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+        orientation_W_B_.w(), orientation_W_B_.x(), orientation_W_B_.y(),
+        orientation_W_B_.z(), // orientation quaternion
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
 
     gv_init_ << init_lin_vel_W.x(), init_lin_vel_W.y(), init_lin_vel_W.z(),
-                init_ang_vel_W.x(), init_ang_vel_W.y(), init_ang_vel_W.z(),
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
+        init_ang_vel_W.x(), init_ang_vel_W.y(), init_ang_vel_W.z(), 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0;
 
     // reset reference
-    Eigen::Vector3d ref_delta_position(unifDistPlusMinusOne_(gen_), unifDistPlusMinusOne_(gen_), unifDistPlusMinusOne_(gen_));
+    Eigen::Vector3d ref_delta_position(unifDistPlusMinusOne_(gen_),
+                                       unifDistPlusMinusOne_(gen_),
+                                       unifDistPlusMinusOne_(gen_));
     ref_delta_position.normalize();
-    ref_position_ = position_W_ + initialDistanceOffset_ * unifDistPlusMinusOne_(gen_) * ref_delta_position;
+    ref_position_ = position_W_ + initialDistanceOffset_ *
+                                      unifDistPlusMinusOne_(gen_) *
+                                      ref_delta_position;
 
-    Eigen::Vector3d ref_delta_orientation(unifDistPlusMinusOne_(gen_), unifDistPlusMinusOne_(gen_), unifDistPlusMinusOne_(gen_));
+    Eigen::Vector3d ref_delta_orientation(unifDistPlusMinusOne_(gen_),
+                                          unifDistPlusMinusOne_(gen_),
+                                          unifDistPlusMinusOne_(gen_));
     ref_delta_orientation.normalize();
-    double ref_delta_angle = unifDistPlusMinusOne_(gen_) * initialAngularOffset_;
-//    std::cout << "ref delta angle " << ref_delta_angle << std::endl;
-//    std::cout << "ref delta pos\n" << ref_position_ - gc_init_.segment(0,3) << std::endl;
-    Eigen::Quaterniond ref_delta_quaternion(Eigen::AngleAxisd(ref_delta_angle, ref_delta_orientation));
+    double ref_delta_angle =
+        unifDistPlusMinusOne_(gen_) * initialAngularOffset_;
+    //    std::cout << "ref delta angle " << ref_delta_angle << std::endl;
+    //    std::cout << "ref delta pos\n" << ref_position_ -
+    //    gc_init_.segment(0,3) << std::endl;
+    Eigen::Quaterniond ref_delta_quaternion(
+        Eigen::AngleAxisd(ref_delta_angle, ref_delta_orientation));
     ref_delta_quaternion.normalize();
     Eigen::Quaterniond ref_quaternion = orientation_W_B_ * ref_delta_quaternion;
     ref_quaternion.normalize();
     ref_orientation_ = ref_quaternion;
 
     controller_.setRef(ref_position_, ref_orientation_);
-//    std::cout << "ref_delta_angle deg: " << ref_delta_angle / M_PI * 180.0 << std::endl;
-//    std::cout << "orientation_W_B_ coeffs: " << orientation_W_B_.coeffs() << std::endl;
-//    std::cout << "init orientation_W_B_ coeffs: " << orientation_W_B_.coeffs() << std::endl;
-//    std::cout << "ref_delta_quaternion coeffs: " << ref_delta_quaternion.coeffs() << std::endl;
-//    std::cout << "ref_quaternion coeffs: " << ref_quaternion.coeffs() << std::endl;
-//    double error_angle = ref_orientation_.angularDistance(orientation_W_B_);
-//    std::cout << "initial error angle: " << error_angle<< std::endl;
+    //    std::cout << "ref_delta_angle deg: " << ref_delta_angle / M_PI * 180.0
+    //    << std::endl; std::cout << "orientation_W_B_ coeffs: " <<
+    //    orientation_W_B_.coeffs() << std::endl; std::cout << "init
+    //    orientation_W_B_ coeffs: " << orientation_W_B_.coeffs() << std::endl;
+    //    std::cout << "ref_delta_quaternion coeffs: " <<
+    //    ref_delta_quaternion.coeffs() << std::endl; std::cout <<
+    //    "ref_quaternion coeffs: " << ref_quaternion.coeffs() << std::endl;
+    //    double error_angle =
+    //    ref_orientation_.angularDistance(orientation_W_B_); std::cout <<
+    //    "initial error angle: " << error_angle<< std::endl;
   }
 
-  void computeErrorMetrics(double& waypointDist, double& errorAngle) {
+  void computeErrorMetrics(double &waypointDist, double &errorAngle) {
     // Maybe want to clamp the error terms?
     waypointDist = (position_W_gt_ - ref_position_).squaredNorm();
 
-//    Eigen::Quaterniond current_quat(gc_[3], gc_[4], gc_[5], gc_[6]);
+    //    Eigen::Quaterniond current_quat(gc_[3], gc_[4], gc_[5], gc_[6]);
     errorAngle = orientation_W_B_gt_.angularDistance(ref_orientation_);
   }
 
-  Eigen::Quaterniond QuaternionFromTwoVectors(Eigen::Vector3d _orientation_vec_1, Eigen::Vector3d _orientation_vec_2) {
+  Eigen::Quaterniond
+  QuaternionFromTwoVectors(Eigen::Vector3d _orientation_vec_1,
+                           Eigen::Vector3d _orientation_vec_2) {
     Eigen::Matrix3d orientation_mat;
     orientation_mat.setIdentity();
-    if (_orientation_vec_1.norm() > 0 && _orientation_vec_2.norm() > 0 && _orientation_vec_1.cross(_orientation_vec_2).norm() > 0) {
+    if (_orientation_vec_1.norm() > 0 && _orientation_vec_2.norm() > 0 &&
+        _orientation_vec_1.cross(_orientation_vec_2).norm() > 0) {
       // Gram-Schmidt
       Eigen::Vector3d e1 = _orientation_vec_1 / _orientation_vec_1.norm();
       Eigen::Vector3d u2 = _orientation_vec_2 - e1.dot(_orientation_vec_2) * e1;
@@ -429,14 +537,14 @@ class ENVIRONMENT : public RaisimGymEnv {
     return Eigen::Quaterniond(orientation_mat);
   }
 
-
   int gcDim_, gvDim_, nJoints_, gcDim_shelf_, gvDim_shelf_, nJoints_shelf_;
   bool visualizable_ = false;
   bool onlyInteraction = true;
-  raisim::ArticulatedSystem* ouzel_;
-  raisim::ArticulatedSystem* shelf_;
+  raisim::ArticulatedSystem *ouzel_;
+  raisim::ArticulatedSystem *shelf_;
   Eigen::VectorXd gc_init_, gv_init_, gc_, gv_, pTarget_, pTarget12_, vTarget_;
-  Eigen::VectorXd gc_init_shelf_, gv_init_shelf_, gc_shelf_, gv_shelf_, pTarget_shelf_, pTarget12_shelf_, vTarget_shelf_;
+  Eigen::VectorXd gc_init_shelf_, gv_init_shelf_, gc_shelf_, gv_shelf_,
+      pTarget_shelf_, pTarget12_shelf_, vTarget_shelf_;
   double initialDistanceOffset_;
   double initialAngularOffset_;
   double initialLinearVel_;
@@ -450,13 +558,15 @@ class ENVIRONMENT : public RaisimGymEnv {
   double terminalSuccessLinearVel_;
   double terminalSuccessAngularVel_;
   Eigen::VectorXd actionMean_, actionStd_;
-//  Eigen::VectorXd actionMean_, actionStd_, obDouble_;
+  //  Eigen::VectorXd actionMean_, actionStd_, obDouble_;
   Eigen::Vector3d position_W_, bodyLinearVel_, bodyAngularVel_;
-  Eigen::Vector3d position_W_shelf_, bodyLinearVel_shelf_, bodyAngularVel_shelf_;
+  Eigen::Vector3d position_W_shelf_, bodyLinearVel_shelf_,
+      bodyAngularVel_shelf_;
   Eigen::VectorXd odometry_measurement, odometry_measurement_shelf;
   Eigen::Quaterniond orientation_W_B_, orientation_W_B_shelf_;
   Eigen::Vector3d position_W_gt_, bodyLinearVel_gt_, bodyAngularVel_gt_;
-  Eigen::Vector3d position_W_shelf_gt_, bodyLinearVel_shelf_gt_, bodyAngularVel_shelf_gt_;
+  Eigen::Vector3d position_W_shelf_gt_, bodyLinearVel_shelf_gt_,
+      bodyAngularVel_shelf_gt_;
   Eigen::Quaterniond orientation_W_B_gt_, orientation_W_B_shelf_gt_;
   std::set<size_t> footIndices_;
   Eigen::Vector3d ref_position_;
@@ -472,5 +582,4 @@ class ENVIRONMENT : public RaisimGymEnv {
 };
 thread_local std::mt19937 raisim::ENVIRONMENT::gen_;
 
-}
-
+} // namespace raisim

--- a/raisimGymTorch/raisimGymTorch/env/envs/rsg_ouzel/include/sensors.h
+++ b/raisimGymTorch/raisimGymTorch/env/envs/rsg_ouzel/include/sensors.h
@@ -4,8 +4,8 @@
  */
 
 #include "raisim/World.hpp"
-#include <boost/circular_buffer.hpp>
 #include <Eigen/Core>
+#include <boost/circular_buffer.hpp>
 
 #include <deque>
 
@@ -15,606 +15,672 @@
 #define RAISIM_SIMULATOR_SENSORS_
 
 /// Returns the 3D cross product Skew symmetric matrix of a given 3D vector.
-template<class Derived>
-inline Eigen::Matrix<typename Derived::Scalar, 3, 3> Skew(
-    const Eigen::MatrixBase<Derived> & vec) {
+template <class Derived>
+inline Eigen::Matrix<typename Derived::Scalar, 3, 3>
+Skew(const Eigen::MatrixBase<Derived> &vec) {
   EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(Derived, 3);
-  return (Eigen::Matrix<typename Derived::Scalar, 3, 3>() << 0.0, -vec[2], vec[1],
-      vec[2], 0.0, -vec[0], -vec[1], vec[0], 0.0).finished();
+  return (Eigen::Matrix<typename Derived::Scalar, 3, 3>() << 0.0, -vec[2],
+          vec[1], vec[2], 0.0, -vec[0], -vec[1], vec[0], 0.0)
+      .finished();
 }
 
 class medianFilter {
-  public:
-    medianFilter(int size) : elements_(size) {
-      size_ = size;
-    }
+public:
+  medianFilter(int size) : elements_(size) { size_ = size; }
 
-    double update(double newVal) {
-      elements_.push_back(newVal);
-      if(elements_.size()<size_) return newVal;
+  double update(double newVal) {
+    elements_.push_back(newVal);
+    if (elements_.size() < size_)
+      return newVal;
 
-      std::vector<double> sortedElements(size_);
-      for(int i=0; i<size_; i++)
-        sortedElements.push_back(elements_[i]);
-      std::sort(sortedElements.begin(),sortedElements.end());
-      return sortedElements[floor(size_/2)];  
-    }
+    std::vector<double> sortedElements(size_);
+    for (int i = 0; i < size_; i++)
+      sortedElements.push_back(elements_[i]);
+    std::sort(sortedElements.begin(), sortedElements.end());
+    return sortedElements[floor(size_ / 2)];
+  }
 
-  private:
-    boost::circular_buffer<double> elements_;
-    int size_;
+private:
+  boost::circular_buffer<double> elements_;
+  int size_;
 };
 
 class medianFilterXd {
-  public:
-    medianFilterXd(int size, int vectorSize) {
-      vectorSize_ = vectorSize;
-      for(int i=0; i<vectorSize; i++)
-        filters_.push_back(new medianFilter(size));
-    }
+public:
+  medianFilterXd(int size, int vectorSize) {
+    vectorSize_ = vectorSize;
+    for (int i = 0; i < vectorSize; i++)
+      filters_.push_back(new medianFilter(size));
+  }
 
-    Eigen::VectorXd update(Eigen::VectorXd newVec) {
-      Eigen::VectorXd filtVec(vectorSize_);
+  Eigen::VectorXd update(Eigen::VectorXd newVec) {
+    Eigen::VectorXd filtVec(vectorSize_);
 
-      for(int i=0; i<vectorSize_; i++)
-        filtVec(i) = filters_[i]->update(newVec(i));
+    for (int i = 0; i < vectorSize_; i++)
+      filtVec(i) = filters_[i]->update(newVec(i));
 
-      return filtVec;
-    }
+    return filtVec;
+  }
 
-  private:
-    std::vector<medianFilter*> filters_; 
-    int vectorSize_;
+private:
+  std::vector<medianFilter *> filters_;
+  int vectorSize_;
 };
 
 namespace raisim_sensors {
 
-  enum sensorTypes {
-    ACCELEROMETER,
-    GYROSCOPE,
-    IMU,
-    VICON,
-    ODOMETRY,
-    FORCE,
-    CONTACT
+enum sensorTypes {
+  ACCELEROMETER,
+  GYROSCOPE,
+  IMU,
+  VICON,
+  ODOMETRY,
+  FORCE,
+  CONTACT
+};
+
+/**
+ * \brief IMU noise parameters
+ * \param[in] noise_density
+ * \param[in] random_walk
+ * \param[in] bias_correlation_time
+ * \param[in] turnOnBias_sigma
+ */
+struct imu_param {
+  double noise_density;
+  double random_walk;
+  double bias_correlation_time;
+  double turnOnBias_sigma;
+};
+
+/**
+ * \class noise
+ * \brief Base noise class
+ */
+template <class T> class noise {
+public:
+  /// \brief Noise constructor.
+  /// \param[in] T noise vector type
+  /// \param[in] sampleTime noise computation sample time
+  noise(double sampleTime) : sampleTime_(sampleTime) {
+    standardNormalDistribution_ = std::normal_distribution<double>(0.0, 1.0);
   };
 
-  /**
-  * \brief IMU noise parameters
-  * \param[in] noise_density
-  * \param[in] random_walk
-  * \param[in] bias_correlation_time
-  * \param[in] turnOnBias_sigma
-  */
-  struct imu_param {
-    double noise_density;
-    double random_walk;
-    double bias_correlation_time;
-    double turnOnBias_sigma;
-  };
+  /// \brief Get sensor noise.
+  /// \return the sensor noise
+  virtual T getNoise() = 0;
 
-  /**
-   * \class noise
-   * \brief Base noise class
-   */
-  template <class T>
-  class noise {
-    public:
-      /// \brief Noise constructor.
-      /// \param[in] T noise vector type
-      /// \param[in] sampleTime noise computation sample time
-      noise(double sampleTime) : sampleTime_(sampleTime) {
-        standardNormalDistribution_ = std::normal_distribution<double>(0.0, 1.0);
-      };
+protected:
+  double sampleTime_;
+  T noise_;
+  std::mt19937 randomGenerator_;
+  std::normal_distribution<double> standardNormalDistribution_;
+};
 
-      /// \brief Get sensor noise.
-      /// \return the sensor noise
-      virtual T getNoise() = 0;
-    protected:
-      double sampleTime_;
-      T noise_;
-      std::mt19937 randomGenerator_;
-      std::normal_distribution<double> standardNormalDistribution_;
-  };
+/**
+ * \class imuNoise
+ * \brief IMU noise class
+ */
+class imuNoise : public noise<Eigen::Vector3d> {
+public:
+  /// \brief IMU noise constructor.
+  /// \param[in] sampleTime noise computation sample time
+  /// \param[in] parameters IMU noise parameters
+  imuNoise(double sampleTime, imu_param parameters);
+  /// \brief Get sensor noise.
+  /// \return the sensor noise
+  Eigen::Vector3d getNoise();
 
-  /**
-   * \class imuNoise
-   * \brief IMU noise class
-   */
-  class imuNoise : public noise<Eigen::Vector3d> {
-    public:
-       /// \brief IMU noise constructor.
-      /// \param[in] sampleTime noise computation sample time
-      /// \param[in] parameters IMU noise parameters
-      imuNoise(double sampleTime, imu_param parameters);
-      /// \brief Get sensor noise.
-      /// \return the sensor noise
-      Eigen::Vector3d getNoise();
-    private:
-      imu_param params_;
-      Eigen::Vector3d bias_, turnOnBias_;
-  };
+private:
+  imu_param params_;
+  Eigen::Vector3d bias_, turnOnBias_;
+};
 
-    /**
-   * \class imuNoise
-   * \brief IMU noise class
-   */
-    class odometryNoise : public noise<Eigen::VectorXd> {
-    public:
-        /// \brief IMU noise constructor.
-        /// \param[in] sampleTime noise computation sample time
-        /// \param[in] parameters IMU noise parameters
-        odometryNoise(double sampleTime, const Yaml::Node& cfg);
-        /// \brief Get sensor noise.
-        /// \return the sensor noise
-        Eigen::VectorXd getNoise();
-    private:
-        double pos_std_, orient_std_, lin_vel_std_, ang_vel_std_;
-        Eigen::Vector3d bias_, turnOnBias_;
-    };
+/**
+ * \class imuNoise
+ * \brief IMU noise class
+ */
+class odometryNoise : public noise<Eigen::VectorXd> {
+public:
+  /// \brief IMU noise constructor.
+  /// \param[in] sampleTime noise computation sample time
+  /// \param[in] parameters IMU noise parameters
+  odometryNoise(double sampleTime, const Yaml::Node &cfg);
+  /// \brief Get sensor noise.
+  /// \return the sensor noise
+  Eigen::VectorXd getNoise();
 
-  /**
-   * \class virtualSensor
-   * \brief Virtual class to collect all the sensors together
-   */
-  class virtualSensor {
-    public:
-      /// \brief virtual sensor constructor.
-      virtualSensor() {};
-      /// \brief update sensor value.
-      virtual void update() = 0;
-      /// \brief get sensor type.
-      /// \return sensor type
-      virtual sensorTypes getType() = 0;
-      /// \brief Update sample time.
-      /// \param[in] sampleTime sample time to set in seconds
-      virtual void updateSampleTime(const double sampleTime) = 0;
-  };
+private:
+  double pos_std_, orient_std_, lin_vel_std_, ang_vel_std_;
+  Eigen::Vector3d bias_, turnOnBias_;
+};
 
-  /**
-  * \class sensor
-  * \brief Base sensor class
-  * \param[in] T sensor vector type
-  * \param[in] msg message to be published type
-  */
-  template <class T>
-  class sensor : public virtualSensor{
-    public:
-      /// \brief base sensor constructor.
-      /// \param[in] sampleTime sample time of the simulated world
-      /// \param[in] noise_source noise source for the measured quantity (NULL if no noise)
-      sensor( double sampleTime, noise<T> * noise_source = NULL)
+/**
+ * \class virtualSensor
+ * \brief Virtual class to collect all the sensors together
+ */
+class virtualSensor {
+public:
+  /// \brief virtual sensor constructor.
+  virtualSensor(){};
+  /// \brief update sensor value.
+  virtual void update() = 0;
+  /// \brief get sensor type.
+  /// \return sensor type
+  virtual sensorTypes getType() = 0;
+  /// \brief Update sample time.
+  /// \param[in] sampleTime sample time to set in seconds
+  virtual void updateSampleTime(const double sampleTime) = 0;
+};
+
+/**
+ * \class sensor
+ * \brief Base sensor class
+ * \param[in] T sensor vector type
+ * \param[in] msg message to be published type
+ */
+template <class T> class sensor : public virtualSensor {
+public:
+  /// \brief base sensor constructor.
+  /// \param[in] sampleTime sample time of the simulated world
+  /// \param[in] noise_source noise source for the measured quantity (NULL if no
+  /// noise)
+  sensor(double sampleTime, noise<T> *noise_source = NULL)
       : sampleTime_(sampleTime), noiseSource_(noise_source) {
-        msgReady_ = false;
-      };
+    msgReady_ = false;
+  };
 
-      /// \brief update sensor value.
-      virtual void update() = 0;
-      /// \brief get sensor type.
-      /// \return sensor type
-      virtual sensorTypes getType() = 0;
+  /// \brief update sensor value.
+  virtual void update() = 0;
+  /// \brief get sensor type.
+  /// \return sensor type
+  virtual sensorTypes getType() = 0;
 
-      /// \brief Update sample time.
-      /// \param[in] sampleTime sample time to set in seconds
-      void updateSampleTime(const double sampleTime) {sampleTime_=sampleTime;};
+  /// \brief Update sample time.
+  /// \param[in] sampleTime sample time to set in seconds
+  void updateSampleTime(const double sampleTime) { sampleTime_ = sampleTime; };
 
-      /// \brief get noisy measurement.
-      /// \return the measurement
-      T getMeas() {return measure_;};
-      /// \brief get ground truth measurement.
-      /// \return the measurement
-      T getMeasGT() {return measureGT_;};
+  /// \brief get noisy measurement.
+  /// \return the measurement
+  T getMeas() { return measure_; };
+  /// \brief get ground truth measurement.
+  /// \return the measurement
+  T getMeasGT() { return measureGT_; };
 
-    protected:
-      /// \brief attach sensor to the link.
-      /// \param[in] sensor_link_name link name
-      size_t attachToLink(std::string sensor_link_name) {
-        size_t base_link;
+protected:
+  /// \brief attach sensor to the link.
+  /// \param[in] sensor_link_name link name
+  size_t attachToLink(std::string sensor_link_name) {
+    size_t base_link;
 
-        base_link = robot_->getFrameIdxByName(sensor_link_name);
-        if(base_link!=-1) return base_link;
+    // std::cout << sensor_link_name << std::endl;
 
-        //Else, let's try with _joint instead of _link
-        std::string link = "link";
-        const std::string joint = "joint";
-        size_t pos = sensor_link_name.find(link);
-        if(pos!=std::string::npos) {
-          sensor_link_name.replace(pos,joint.length(),joint);
-          base_link = robot_->getFrameByName(sensor_link_name).currentBodyId;
-          if(base_link!=-1) {
-            return base_link;
-          } 
-        }
-        base_link = 0;
+    base_link = robot_->getFrameIdxByName(sensor_link_name);
+    if (base_link != -1) {
+      // std::cout << "attachToLink: FOUND: " << sensor_link_name << std::endl;
+      return base_link;
+    }
+
+    // Else, let's try with _joint instead of _link
+    std::string link = "link";
+    const std::string joint = "joint";
+    size_t pos = sensor_link_name.find(link);
+    std::cout << "attachToLink: " << sensor_link_name << " NOT FOUND!"
+              << std::endl;
+    if (pos != std::string::npos) {
+      sensor_link_name.replace(pos, joint.length(), joint);
+      std::cout << "attachToLink:  TRYING WITH: " << sensor_link_name
+                << std::endl;
+      base_link = robot_->getFrameIdxByName(sensor_link_name);
+      if (base_link != -1) {
+        base_link = robot_->getFrameByName(sensor_link_name).currentBodyId;
+        std::cout << "attachToLink:  FOUND: " << sensor_link_name << std::endl;
         return base_link;
-      };
-      noise<T> * noiseSource_;
-      double sampleTime_;
-      T measure_;
-      T measureGT_;
-      bool msgReady_, updatePublish_;
-      size_t baseLink_;
-      raisim::ArticulatedSystem * robot_;
+      }
+    }
+
+    std::cout << "attachToLink: " << sensor_link_name
+              << "NOT FOUND! Please use one of the following names: "
+              << std::endl;
+    robot_->printOutFrameNamesInOrder();
+    exit(1);
+    base_link = 0;
+    return base_link;
+  };
+  noise<T> *noiseSource_;
+  double sampleTime_;
+  T measure_;
+  T measureGT_;
+  bool msgReady_, updatePublish_;
+  size_t baseLink_;
+  raisim::ArticulatedSystem *robot_;
+};
+
+/**
+ * \class accelerometer
+ * \brief Accelerometer sensor class
+ */
+
+class accelerometer : public sensor<Eigen::Vector3d> {
+public:
+  /// \brief accelerometer sensor constructor.
+  /// \param[in] robot robot where to place the accelerometer
+  /// \param[in] sampleTime sample time of the simulated world
+  /// \param[in] sensor_link_name URDF link name where to place the sensor
+  /// \param[in] imu_wrt_link_offset offset of the IMU w.r.t. the link frame
+  /// origin \param[in] world pointer to the simulated world \param[in]
+  /// noise_source noise source for the measured quantity (NULL if no noise)
+  accelerometer(raisim::ArticulatedSystem *robot, double sampleTime,
+                const std::string sensor_link_name,
+                Eigen::Vector3d imu_wrt_link_offset, Eigen::Vector3d gravity,
+                noise<Eigen::Vector3d> *noise_source = NULL)
+      : sensor(sampleTime, noise_source),
+        imu_wrt_link_offset_(imu_wrt_link_offset), gravity_(gravity) {
+    robot_ = robot;
+    baseLink_ = attachToLink(sensor_link_name);
+    prev_robot_linear_velocity_W_.setZero();
   };
 
+  /// \brief update sensor value.
+  void update();
+  /// \brief get sensor type.
+  /// \return sensor type
+  sensorTypes getType() { return sensorTypes::ACCELEROMETER; };
 
-  /**
-   * \class accelerometer
-   * \brief Accelerometer sensor class
-  */
+private:
+  Eigen::Vector3d gravity_;
+  Eigen::Vector3d imu_wrt_link_offset_;
+  raisim::Vec<3> prev_robot_linear_velocity_W_, prev_imu_linear_velocity_W_;
+};
 
-  class accelerometer : public sensor<Eigen::Vector3d> {
-    public:
-      /// \brief accelerometer sensor constructor.
-      /// \param[in] robot robot where to place the accelerometer
-      /// \param[in] sampleTime sample time of the simulated world
-      /// \param[in] sensor_link_name URDF link name where to place the sensor
-      /// \param[in] imu_wrt_link_offset offset of the IMU w.r.t. the link frame origin
-      /// \param[in] world pointer to the simulated world
-      /// \param[in] noise_source noise source for the measured quantity (NULL if no noise)
-      accelerometer(raisim::ArticulatedSystem * robot, double sampleTime, const std::string sensor_link_name, Eigen::Vector3d imu_wrt_link_offset, Eigen::Vector3d gravity, noise<Eigen::Vector3d> * noise_source = NULL)
-      : sensor( sampleTime, noise_source), imu_wrt_link_offset_(imu_wrt_link_offset), gravity_(gravity) {
-        robot_ = robot;
-        baseLink_ = attachToLink(sensor_link_name);
-        prev_robot_linear_velocity_W_.setZero();
-        };
-
-      /// \brief update sensor value.
-      void update();
-      /// \brief get sensor type.
-      /// \return sensor type
-      sensorTypes getType() {return sensorTypes::ACCELEROMETER;};
-
-    private:
-      Eigen::Vector3d gravity_;
-      Eigen::Vector3d imu_wrt_link_offset_;
-      raisim::Vec<3> prev_robot_linear_velocity_W_, prev_imu_linear_velocity_W_;
-  };
-
-  /**
-   * \class gyroscope
-  * \brief Gyroscope sensor class
-  */
-  class gyroscope : public sensor<Eigen::Vector3d> {
-    public:
-      /// \brief gyroscope sensor constructor.
-      /// \param[in] robot robot where to place the accelerometer
-      /// \param[in] sampleTime sample time of the simulated world
-      /// \param[in] sensor_link_name URDF link name where to place the sensor
-      /// \param[in] noise_source noise source for the measured quantity (NULL if no noise)
-      gyroscope(raisim::ArticulatedSystem * robot, double sampleTime, const std::string sensor_link_name, noise<Eigen::Vector3d> * noise_source = NULL)
+/**
+ * \class gyroscope
+ * \brief Gyroscope sensor class
+ */
+class gyroscope : public sensor<Eigen::Vector3d> {
+public:
+  /// \brief gyroscope sensor constructor.
+  /// \param[in] robot robot where to place the accelerometer
+  /// \param[in] sampleTime sample time of the simulated world
+  /// \param[in] sensor_link_name URDF link name where to place the sensor
+  /// \param[in] noise_source noise source for the measured quantity (NULL if no
+  /// noise)
+  gyroscope(raisim::ArticulatedSystem *robot, double sampleTime,
+            const std::string sensor_link_name,
+            noise<Eigen::Vector3d> *noise_source = NULL)
       : sensor(sampleTime, noise_source) {
-        robot_ = robot;
-        baseLink_ = attachToLink(sensor_link_name);
-        };
-    
-      /// \brief update sensor value.
-      void update();
-      /// \brief get sensor type.
-      /// \return sensor type
-      sensorTypes getType() {return sensorTypes::GYROSCOPE;};
+    robot_ = robot;
+    baseLink_ = attachToLink(sensor_link_name);
   };
 
-  /**
-  * \class imu
-  * \brief IMU sensor class
-  */
-  class imu : public sensor<Eigen::VectorXd> {
-    public:
-      /// \brief imu sensor constructor.
-      /// \param[in] robot robot where to place the accelerometer
-      /// \param[in] sampleTime sample time of the simulated world
-      /// \param[in] sensor_link_name URDF link name where to place the sensor
-      /// \param[in] imu_wrt_link_offset offset of the IMU w.r.t. the link frame origin
-      /// \param[in] world pointer to the simulated world
-      /// \param[in] accel_noise noise source for the accelerometer quantity (NULL if no noise)
-      /// \param[in] gyro_noise noise source for the gyroscope quantity (NULL if no noise)
-      imu(raisim::ArticulatedSystem * robot, double sampleTime, const std::string sensor_link_name, Eigen::Vector3d imu_wrt_link_offset, Eigen::Vector3d gravity, noise<Eigen::Vector3d> * accel_noise = NULL, noise<Eigen::Vector3d> * gyro_noise = NULL)
+  /// \brief update sensor value.
+  void update();
+  /// \brief get sensor type.
+  /// \return sensor type
+  sensorTypes getType() { return sensorTypes::GYROSCOPE; };
+};
+
+/**
+ * \class imu
+ * \brief IMU sensor class
+ */
+class imu : public sensor<Eigen::VectorXd> {
+public:
+  /// \brief imu sensor constructor.
+  /// \param[in] robot robot where to place the accelerometer
+  /// \param[in] sampleTime sample time of the simulated world
+  /// \param[in] sensor_link_name URDF link name where to place the sensor
+  /// \param[in] imu_wrt_link_offset offset of the IMU w.r.t. the link frame
+  /// origin \param[in] world pointer to the simulated world \param[in]
+  /// accel_noise noise source for the accelerometer quantity (NULL if no noise)
+  /// \param[in] gyro_noise noise source for the gyroscope quantity (NULL if no
+  /// noise)
+  imu(raisim::ArticulatedSystem *robot, double sampleTime,
+      const std::string sensor_link_name, Eigen::Vector3d imu_wrt_link_offset,
+      Eigen::Vector3d gravity, noise<Eigen::Vector3d> *accel_noise = NULL,
+      noise<Eigen::Vector3d> *gyro_noise = NULL)
       : sensor(sampleTime, NULL) {
-          accel_ = new accelerometer(robot, sampleTime, sensor_link_name, imu_wrt_link_offset, gravity, accel_noise);
-          gyro_  = new gyroscope(robot, sampleTime, sensor_link_name, gyro_noise);  
-          measureGT_.resize(6);
-          measure_.resize(6);
-          measure_.setZero();
-          measureGT_.setZero();
-        };
-
-      /// \brief imu sensor constructor.
-      /// \param[in] robot robot where to place the accelerometer
-      /// \param[in] sampleTime sample time of the simulated world
-      /// \param[in] imu_wrt_link_offset offset of the IMU w.r.t. the link frame origin
-      /// \param[in] world pointer to the simulated world
-      /// \param[in] params IMU parameters
-      imu(raisim::ArticulatedSystem * robot, double sampleTime, Eigen::Vector3d imu_wrt_link_offset, Eigen::Vector3d gravity, const Yaml::Node& cfg)
-      : sensor(sampleTime, NULL) {
-        raisim_sensors::imu_param accel_params, gyro_params;
-        accel_params.bias_correlation_time  = cfg["accelerometerBiasCorrelationTime"].template As<float>();
-        accel_params.turnOnBias_sigma       = cfg["accelerometerTurnOnBiasSigma"].template As<float>();
-        accel_params.noise_density          = cfg["accelerometerNoiseDensity"].template As<float>();
-        accel_params.random_walk            = cfg["accelerometerRandomWalk"].template As<float>();
-        gyro_params.bias_correlation_time   = cfg["gyroscopeBiasCorrelationTime"].template As<float>();
-        gyro_params.turnOnBias_sigma        = cfg["gyroscopeTurnOnBiasSigma"].template As<float>();
-        gyro_params.noise_density           = cfg["gyroscopeNoiseDensity"].template As<float>();
-        gyro_params.random_walk             = cfg["gyroscopeRandomWalk"].template As<float>();
-
-        std::string link_name = cfg["linkName"].template As<std::string>();
-        std::string sensorNamespace = cfg["robotNamespace"].template As<std::string>();
-        imuNoise *accelNoise = new raisim_sensors::imuNoise(sampleTime,accel_params);
-        imuNoise *gyroNoise = new raisim_sensors::imuNoise(sampleTime,gyro_params);
-
-        accel_ = new accelerometer(robot, sampleTime, link_name, imu_wrt_link_offset, gravity, accelNoise);
-        gyro_  = new gyroscope(robot, sampleTime, link_name, gyroNoise);  
-        measureGT_.resize(6);
-        measure_.resize(6);
-        measure_.setZero();
-        measureGT_.setZero();
-      };
-      imu() : sensor (0.0, NULL) { }
-    
-      /// \brief update sensor value.
-      void update();
-      /// \brief get sensor type.
-      /// \return sensor type
-      sensorTypes getType() {return sensorTypes::IMU;};
-
-    private:
-      gyroscope *gyro_;
-      accelerometer *accel_;
+    accel_ = new accelerometer(robot, sampleTime, sensor_link_name,
+                               imu_wrt_link_offset, gravity, accel_noise);
+    gyro_ = new gyroscope(robot, sampleTime, sensor_link_name, gyro_noise);
+    measureGT_.resize(6);
+    measure_.resize(6);
+    measure_.setZero();
+    measureGT_.setZero();
   };
 
-  /**
-   * \class vicon
-  * \brief Vicon sensor class
-  */
-  class vicon : public sensor<Eigen::VectorXd> {
-    public:
-      /// \brief vicon sensor constructor.
-      ///\param[in] robot robot where to place the sensor
-      ///\param[in] sampleTime sample time of the simulated world
-      ///\param[in] child_frame_name name of the frame for the published transform
-      ///\param[in] sensor_link_name URDF link name where to place the sensor
-      ///\param[in] noise_source noise source for the measured quantity (NULL if no noise)
-      vicon(raisim::ArticulatedSystem * robot, double sampleTime, const std::string child_frame_name, const std::string sensor_link_name , noise<Eigen::VectorXd> * noise_source = NULL)
+  /// \brief imu sensor constructor.
+  /// \param[in] robot robot where to place the accelerometer
+  /// \param[in] sampleTime sample time of the simulated world
+  /// \param[in] imu_wrt_link_offset offset of the IMU w.r.t. the link frame
+  /// origin \param[in] world pointer to the simulated world \param[in] params
+  /// IMU parameters
+  imu(raisim::ArticulatedSystem *robot, double sampleTime,
+      Eigen::Vector3d imu_wrt_link_offset, Eigen::Vector3d gravity,
+      const Yaml::Node &cfg)
+      : sensor(sampleTime, NULL) {
+    raisim_sensors::imu_param accel_params, gyro_params;
+    accel_params.bias_correlation_time =
+        cfg["accelerometerBiasCorrelationTime"].template As<float>();
+    accel_params.turnOnBias_sigma =
+        cfg["accelerometerTurnOnBiasSigma"].template As<float>();
+    accel_params.noise_density =
+        cfg["accelerometerNoiseDensity"].template As<float>();
+    accel_params.random_walk =
+        cfg["accelerometerRandomWalk"].template As<float>();
+    gyro_params.bias_correlation_time =
+        cfg["gyroscopeBiasCorrelationTime"].template As<float>();
+    gyro_params.turnOnBias_sigma =
+        cfg["gyroscopeTurnOnBiasSigma"].template As<float>();
+    gyro_params.noise_density =
+        cfg["gyroscopeNoiseDensity"].template As<float>();
+    gyro_params.random_walk = cfg["gyroscopeRandomWalk"].template As<float>();
+
+    std::string link_name = cfg["linkName"].template As<std::string>();
+    std::string sensorNamespace =
+        cfg["robotNamespace"].template As<std::string>();
+    imuNoise *accelNoise =
+        new raisim_sensors::imuNoise(sampleTime, accel_params);
+    imuNoise *gyroNoise = new raisim_sensors::imuNoise(sampleTime, gyro_params);
+
+    accel_ = new accelerometer(robot, sampleTime, link_name,
+                               imu_wrt_link_offset, gravity, accelNoise);
+    gyro_ = new gyroscope(robot, sampleTime, link_name, gyroNoise);
+    measureGT_.resize(6);
+    measure_.resize(6);
+    measure_.setZero();
+    measureGT_.setZero();
+  };
+  imu() : sensor(0.0, NULL) {}
+
+  /// \brief update sensor value.
+  void update();
+  /// \brief get sensor type.
+  /// \return sensor type
+  sensorTypes getType() { return sensorTypes::IMU; };
+
+private:
+  gyroscope *gyro_;
+  accelerometer *accel_;
+};
+
+/**
+ * \class vicon
+ * \brief Vicon sensor class
+ */
+class vicon : public sensor<Eigen::VectorXd> {
+public:
+  /// \brief vicon sensor constructor.
+  ///\param[in] robot robot where to place the sensor
+  ///\param[in] sampleTime sample time of the simulated world
+  ///\param[in] child_frame_name name of the frame for the published transform
+  ///\param[in] sensor_link_name URDF link name where to place the sensor
+  ///\param[in] noise_source noise source for the measured quantity (NULL if no
+  /// noise)
+  vicon(raisim::ArticulatedSystem *robot, double sampleTime,
+        const std::string child_frame_name, const std::string sensor_link_name,
+        noise<Eigen::VectorXd> *noise_source = NULL)
       : sensor(sampleTime, noise_source) {
-        robot_ = robot;
-        baseLink_ = attachToLink(sensor_link_name);
-        childFrameName_ = child_frame_name;
-        articulated_ = true;
-        measureGT_.resize(7);
-        measure_.resize(7);
-        measure_.setZero();
-        measureGT_.setZero();
-      };
+    robot_ = robot;
+    baseLink_ = attachToLink(sensor_link_name);
+    childFrameName_ = child_frame_name;
+    articulated_ = true;
+    measureGT_.resize(7);
+    measure_.resize(7);
+    measure_.setZero();
+    measureGT_.setZero();
+  };
 
-      /// \brief vicon sensor constructor.
-      ///\param[in] robot robot where to place the sensor
-      ///\param[in] sampleTime sample time of the simulated world
-      ///\param[in] params Vicon sensor parameters
-      vicon(raisim::ArticulatedSystem * robot, double sampleTime, const Yaml::Node& cfg)
+  /// \brief vicon sensor constructor.
+  ///\param[in] robot robot where to place the sensor
+  ///\param[in] sampleTime sample time of the simulated world
+  ///\param[in] params Vicon sensor parameters
+  vicon(raisim::ArticulatedSystem *robot, double sampleTime,
+        const Yaml::Node &cfg)
       : sensor(sampleTime, NULL) {
-        std::string sensor_link_name = cfg["linkName"].template As<std::string>();
-        childFrameName_ = cfg["childFrameId"].template As<std::string>();
-        robot_ = robot;
-        baseLink_ = attachToLink(sensor_link_name);
-        articulated_ = true;
-        measureGT_.resize(7);
-        measure_.resize(7);
-        measure_.setZero();
-        measureGT_.setZero();
-      };
-      
-      /// \brief vicon sensor constructor.
-      ///\param[in] obj Single object where to place the sensor
-      ///\param[in] sampleTime sample time of the simulated world
-      ///\param[in] child_frame_name name of the frame for the published transform
-      ///\param[in] sensor_link_name URDF link name where to place the sensor
-      ///\param[in] noise_source noise source for the measured quantity (NULL if no noise)
-      vicon(raisim::SingleBodyObject * obj, double sampleTime, const std::string child_frame_name, noise<Eigen::VectorXd> * noise_source = NULL)
+    std::string sensor_link_name = cfg["linkName"].template As<std::string>();
+    childFrameName_ = cfg["childFrameId"].template As<std::string>();
+    robot_ = robot;
+    baseLink_ = attachToLink(sensor_link_name);
+    articulated_ = true;
+    measureGT_.resize(7);
+    measure_.resize(7);
+    measure_.setZero();
+    measureGT_.setZero();
+  };
+
+  /// \brief vicon sensor constructor.
+  ///\param[in] obj Single object where to place the sensor
+  ///\param[in] sampleTime sample time of the simulated world
+  ///\param[in] child_frame_name name of the frame for the published transform
+  ///\param[in] sensor_link_name URDF link name where to place the sensor
+  ///\param[in] noise_source noise source for the measured quantity (NULL if no
+  /// noise)
+  vicon(raisim::SingleBodyObject *obj, double sampleTime,
+        const std::string child_frame_name,
+        noise<Eigen::VectorXd> *noise_source = NULL)
       : sensor(sampleTime, noise_source) {
-        childFrameName_ = child_frame_name;
-        obj_ = obj;
-        articulated_ = false;
-        measureGT_.resize(7);
-        measure_.resize(7);
-        measure_.setZero();
-        measureGT_.setZero();
-      };
-
-      /// \brief vicon sensor constructor.
-      ///\param[in] obj Single object where to place the sensor
-      ///\param[in] sampleTime sample time of the simulated world
-      ///\param[in] params Vicon sensor parameters
-      vicon(raisim::SingleBodyObject * obj, double sampleTime, const Yaml::Node& cfg)
-      : sensor(sampleTime, NULL) {
-        childFrameName_ = cfg["childFrameId"].template As<std::string>();
-        obj_ = obj;
-        articulated_ = false;
-        measureGT_.resize(7);
-        measure_.resize(7);
-        measure_.setZero();
-        measureGT_.setZero();
-      };
-    
-      /// \brief update sensor value.
-      void update();
-      /// \brief get sensor type.
-      /// \return sensor type
-      sensorTypes getType() {return sensorTypes::VICON;};
-
-    private:
-      raisim::SingleBodyObject * obj_;
-      std::string childFrameName_;
-      bool articulated_;
+    childFrameName_ = child_frame_name;
+    obj_ = obj;
+    articulated_ = false;
+    measureGT_.resize(7);
+    measure_.resize(7);
+    measure_.setZero();
+    measureGT_.setZero();
   };
 
-  /**
-   * \class odometry
-  * \brief Odometry sensor class
-  */
-  class odometry : public sensor<Eigen::VectorXd> {
-    public:
-      /// \brief odometry sensor constructor.
-      /// \param[in] robot robot where to place the sensor
-      /// \param[in] sampleTime sample time of the simulated world
-      /// \param[in] child_frame_name name of the frame for the published transform
-      /// \param[in] sensor_link_name URDF link name where to place the sensor
-      /// \param[in] noise_source noise source for the measured quantity (NULL if no noise)
-      odometry(raisim::ArticulatedSystem *robot, double sampleTime, const std::string child_frame_name, const std::string sensor_link_name , noise<Eigen::VectorXd> * noise_source = NULL)
+  /// \brief vicon sensor constructor.
+  ///\param[in] obj Single object where to place the sensor
+  ///\param[in] sampleTime sample time of the simulated world
+  ///\param[in] params Vicon sensor parameters
+  vicon(raisim::SingleBodyObject *obj, double sampleTime, const Yaml::Node &cfg)
+      : sensor(sampleTime, NULL) {
+    childFrameName_ = cfg["childFrameId"].template As<std::string>();
+    obj_ = obj;
+    articulated_ = false;
+    measureGT_.resize(7);
+    measure_.resize(7);
+    measure_.setZero();
+    measureGT_.setZero();
+  };
+
+  /// \brief update sensor value.
+  void update();
+  /// \brief get sensor type.
+  /// \return sensor type
+  sensorTypes getType() { return sensorTypes::VICON; };
+
+private:
+  raisim::SingleBodyObject *obj_;
+  std::string childFrameName_;
+  bool articulated_;
+};
+
+/**
+ * \class odometry
+ * \brief Odometry sensor class
+ */
+class odometry : public sensor<Eigen::VectorXd> {
+public:
+  /// \brief odometry sensor constructor.
+  /// \param[in] robot robot where to place the sensor
+  /// \param[in] sampleTime sample time of the simulated world
+  /// \param[in] child_frame_name name of the frame for the published transform
+  /// \param[in] sensor_link_name URDF link name where to place the sensor
+  /// \param[in] noise_source noise source for the measured quantity (NULL if no
+  /// noise)
+  odometry(raisim::ArticulatedSystem *robot, double sampleTime,
+           const std::string child_frame_name,
+           const std::string sensor_link_name,
+           noise<Eigen::VectorXd> *noise_source = NULL)
       : sensor(sampleTime, noise_source) {
-        robot_ = robot;
-        baseLink_ = attachToLink(sensor_link_name);
-        childFrameName_ = child_frame_name;
-        measureGT_.resize(7+6);
-        measure_.resize(7+6);
-        measure_.setZero();
-        measureGT_.setZero();
-      };
+    robot_ = robot;
+    baseLink_ = attachToLink(sensor_link_name);
+    childFrameName_ = child_frame_name;
+    measureGT_.resize(7 + 6);
+    measure_.resize(7 + 6);
+    measure_.setZero();
+    measureGT_.setZero();
+  };
 
-      /// \brief odometry sensor constructor.
-      /// \param[in] robot robot where to place the sensor
-      /// \param[in] sampleTime sample time of the simulated world
-      /// \param[in] params Odometry sensor parameters
-      odometry(raisim::ArticulatedSystem *robot, double sampleTime, const Yaml::Node& cfg)
+  /// \brief odometry sensor constructor.
+  /// \param[in] robot robot where to place the sensor
+  /// \param[in] sampleTime sample time of the simulated world
+  /// \param[in] params Odometry sensor parameters
+  odometry(raisim::ArticulatedSystem *robot, double sampleTime,
+           const Yaml::Node &cfg)
       : sensor(sampleTime, NULL) {
-        robot_ = robot;
-        std::string sensor_link_name = cfg["linkName"].template As<std::string>();
-        childFrameName_ = cfg["childFrameId"].template As<std::string>();
-        baseLink_ = attachToLink(sensor_link_name);
-        measureGT_.resize(7+6);
-        measure_.resize(7+6);
-        measure_.setZero();
-        measureGT_.setZero();
-      };
-
-      odometry() : sensor(0.0, NULL) { }
-    
-      /// \brief update sensor value.
-      void update();
-      /// \brief get sensor type.
-      /// \return sensor type
-      sensorTypes getType() {return sensorTypes::ODOMETRY;};
-
-    private:
-      std::string childFrameName_;
+    robot_ = robot;
+    std::string sensor_link_name = cfg["linkName"].template As<std::string>();
+    childFrameName_ = cfg["childFrameId"].template As<std::string>();
+    baseLink_ = attachToLink(sensor_link_name);
+    measureGT_.resize(7 + 6);
+    measure_.resize(7 + 6);
+    measure_.setZero();
+    measureGT_.setZero();
   };
 
-  /**
-  * \class force
-  * \brief Force sensor class
-  */
-  class force : public sensor<Eigen::VectorXd> {
-    public:
-      /// \brief force sensor constructor.
-      /// \param[in] robot robot where to place the force sensor
-      /// \param[in] world pointer to the simulated world
-      /// \param[in] sampleTime sample time of the simulated world
-      /// \param[in] sensor_link_name URDF link name where to place the sensor
-      /// \param[in] child_frame_name name of the frame for the published transform
-      /// \param[in] noise_source noise source for the measured quantity (NULL if no noise)
-      force(raisim::ArticulatedSystem *robot, raisim::World *world, double sampleTime, const std::string sensor_link_name, const std::string child_frame_name, noise<Eigen::VectorXd> * noise_source = NULL)
-      : sensor(sampleTime, noise_source), impulseFilter_(3,3),angularImpulseFilter_(3,3) {
-        childFrameName_ = child_frame_name;
-        robot_ = robot;
-        world_ = world;
-        baseLink_ = attachToLink(sensor_link_name);
-        measureGT_.resize(6);
-        measure_.resize(6);
-        measure_.setZero();
-        measureGT_.setZero();
-      };
+  odometry() : sensor(0.0, NULL) {}
 
-      /// \brief force sensor constructor.
-      /// \param[in] robot robot where to place the force sensor
-      /// \param[in] world pointer to the simulated world
-      /// \param[in] sampleTime sample time of the simulated world
-      /// \param[in] child_frame_name name of the frame for the published transform
-      /// \param[in] params force sensor params
-      force(raisim::ArticulatedSystem *robot, raisim::World *world, double sampleTime, const std::string child_frame_name, const Yaml::Node& cfg)
-      : sensor(sampleTime, NULL), impulseFilter_(3,3),angularImpulseFilter_(3,3) {
-        std::string sensor_link_name = cfg["linkName"].template As<std::string>();
-        childFrameName_ = child_frame_name;
-        robot_ = robot;
-        world_ = world;
-        baseLink_ = attachToLink(sensor_link_name);
-        measureGT_.resize(6);
-        measure_.resize(6);
-        measure_.setZero();
-        measureGT_.setZero();
-      };
-    
-      /// \brief update sensor value.
-      void update();
-      /// \brief get sensor type.
-      /// \return sensor type
-      sensorTypes getType() {return sensorTypes::FORCE;};
+  /// \brief update sensor value.
+  void update();
+  /// \brief get sensor type.
+  /// \return sensor type
+  sensorTypes getType() { return sensorTypes::ODOMETRY; };
 
-    private:
-      raisim::World * world_;
-      raisim::MaterialPairProperties contactMatProp_;
-      medianFilterXd impulseFilter_;
-      medianFilterXd angularImpulseFilter_;
-      std::string childFrameName_;
+private:
+  std::string childFrameName_;
+};
+
+/**
+ * \class force
+ * \brief Force sensor class
+ */
+class force : public sensor<Eigen::VectorXd> {
+public:
+  /// \brief force sensor constructor.
+  /// \param[in] robot robot where to place the force sensor
+  /// \param[in] world pointer to the simulated world
+  /// \param[in] sampleTime sample time of the simulated world
+  /// \param[in] sensor_link_name URDF link name where to place the sensor
+  /// \param[in] child_frame_name name of the frame for the published transform
+  /// \param[in] noise_source noise source for the measured quantity (NULL if no
+  /// noise)
+  force(raisim::ArticulatedSystem *robot, raisim::World *world,
+        double sampleTime, const std::string sensor_link_name,
+        const std::string child_frame_name,
+        noise<Eigen::VectorXd> *noise_source = NULL)
+      : sensor(sampleTime, noise_source), impulseFilter_(3, 3),
+        angularImpulseFilter_(3, 3) {
+    childFrameName_ = child_frame_name;
+    robot_ = robot;
+    world_ = world;
+    baseLink_ = attachToLink(sensor_link_name);
+    measureGT_.resize(6);
+    measure_.resize(6);
+    measure_.setZero();
+    measureGT_.setZero();
   };
 
-  /**
-   * \class contact
-  * \brief Contact sensor class. Gives info on the contact friction.
-  */
-  class contact : public sensor<Eigen::VectorXd> {
-    public:
-      /// \brief contact sensor constructor.
-      /// \param[in] robot robot where to place the force sensor
-      /// \param[in] world pointer to the simulated world
-      /// \param[in] sampleTime sample time of the simulated world
-      /// \param[in] sensor_link_name URDF link name where to place the sensor
-      /// \param[in] child_frame_name name of the frame for the published transform
-      /// \param[in] noise_source noise source for the measured quantity (NULL if no noise)
-      contact(raisim::ArticulatedSystem *robot, raisim::World *world, double sampleTime, const std::string sensor_link_name, const std::string child_frame_name, noise<Eigen::VectorXd> * noise_source = NULL)
-      : sensor(sampleTime, noise_source), impulseFilter_(3,3) {
-        childFrameName_ = child_frame_name;
-        robot_ = robot;
-        world_ = world;
-        baseLink_ = attachToLink(sensor_link_name);
-        measureGT_.resize(4);
-        measure_.resize(4);
-        measure_.setZero();
-        measureGT_.setZero();
-      };
-
-      /// \brief contact sensor constructor.
-      /// \param[in] robot robot where to place the force sensor
-      /// \param[in] world pointer to the simulated world
-      /// \param[in] sampleTime sample time of the simulated world
-      /// \param[in] child_frame_name name of the frame for the published transform
-      /// \param[in] params contact sensor parameters
-      contact(raisim::ArticulatedSystem *robot, raisim::World *world, double sampleTime, const std::string child_frame_name, const Yaml::Node& cfg)
-      : sensor(sampleTime, NULL), impulseFilter_(3,3) {
-        std::string sensor_link_name = cfg["linkName"].template As<std::string>();
-        childFrameName_ = child_frame_name;
-        robot_ = robot;
-        world_ = world;
-        baseLink_ = attachToLink(sensor_link_name);
-        measureGT_.resize(4);
-        measure_.resize(4);
-        measure_.setZero();
-        measureGT_.setZero();
-      };
-    
-      /// \brief update sensor value.
-      void update();
-      /// \brief get sensor type.
-      /// \return sensor type
-      sensorTypes getType() {return sensorTypes::CONTACT;};
-
-    private:
-      raisim::World * world_;
-      raisim::MaterialPairProperties contactMatProp_;
-      medianFilterXd impulseFilter_;
-      std::string childFrameName_;
+  /// \brief force sensor constructor.
+  /// \param[in] robot robot where to place the force sensor
+  /// \param[in] world pointer to the simulated world
+  /// \param[in] sampleTime sample time of the simulated world
+  /// \param[in] child_frame_name name of the frame for the published transform
+  /// \param[in] params force sensor params
+  force(raisim::ArticulatedSystem *robot, raisim::World *world,
+        double sampleTime, const std::string child_frame_name,
+        const Yaml::Node &cfg)
+      : sensor(sampleTime, NULL), impulseFilter_(3, 3),
+        angularImpulseFilter_(3, 3) {
+    std::string sensor_link_name = cfg["linkName"].template As<std::string>();
+    childFrameName_ = child_frame_name;
+    robot_ = robot;
+    world_ = world;
+    baseLink_ = attachToLink(sensor_link_name);
+    measureGT_.resize(6);
+    measure_.resize(6);
+    measure_.setZero();
+    measureGT_.setZero();
   };
 
+  /// \brief update sensor value.
+  void update();
+  /// \brief get sensor type.
+  /// \return sensor type
+  sensorTypes getType() { return sensorTypes::FORCE; };
 
+private:
+  raisim::World *world_;
+  raisim::MaterialPairProperties contactMatProp_;
+  medianFilterXd impulseFilter_;
+  medianFilterXd angularImpulseFilter_;
+  std::string childFrameName_;
+};
 
-}
+/**
+ * \class contact
+ * \brief Contact sensor class. Gives info on the contact friction.
+ */
+class contact : public sensor<Eigen::VectorXd> {
+public:
+  /// \brief contact sensor constructor.
+  /// \param[in] robot robot where to place the force sensor
+  /// \param[in] world pointer to the simulated world
+  /// \param[in] sampleTime sample time of the simulated world
+  /// \param[in] sensor_link_name URDF link name where to place the sensor
+  /// \param[in] child_frame_name name of the frame for the published transform
+  /// \param[in] noise_source noise source for the measured quantity (NULL if no
+  /// noise)
+  contact(raisim::ArticulatedSystem *robot, raisim::World *world,
+          double sampleTime, const std::string sensor_link_name,
+          const std::string child_frame_name,
+          noise<Eigen::VectorXd> *noise_source = NULL)
+      : sensor(sampleTime, noise_source), impulseFilter_(3, 3) {
+    childFrameName_ = child_frame_name;
+    robot_ = robot;
+    world_ = world;
+    baseLink_ = attachToLink(sensor_link_name);
+    measureGT_.resize(4);
+    measure_.resize(4);
+    measure_.setZero();
+    measureGT_.setZero();
+  };
+
+  /// \brief contact sensor constructor.
+  /// \param[in] robot robot where to place the force sensor
+  /// \param[in] world pointer to the simulated world
+  /// \param[in] sampleTime sample time of the simulated world
+  /// \param[in] child_frame_name name of the frame for the published transform
+  /// \param[in] params contact sensor parameters
+  contact(raisim::ArticulatedSystem *robot, raisim::World *world,
+          double sampleTime, const std::string child_frame_name,
+          const Yaml::Node &cfg)
+      : sensor(sampleTime, NULL), impulseFilter_(3, 3) {
+    std::string sensor_link_name = cfg["linkName"].template As<std::string>();
+    childFrameName_ = child_frame_name;
+    robot_ = robot;
+    world_ = world;
+    baseLink_ = attachToLink(sensor_link_name);
+    measureGT_.resize(4);
+    measure_.resize(4);
+    measure_.setZero();
+    measureGT_.setZero();
+  };
+
+  /// \brief update sensor value.
+  void update();
+  /// \brief get sensor type.
+  /// \return sensor type
+  sensorTypes getType() { return sensorTypes::CONTACT; };
+
+private:
+  raisim::World *world_;
+  raisim::MaterialPairProperties contactMatProp_;
+  medianFilterXd impulseFilter_;
+  std::string childFrameName_;
+};
+
+} // namespace raisim_sensors
 
 #endif // !RAISIM_SIMULATOR_SENSORS_


### PR DESCRIPTION
Shelf odometry sensor now attached to "measured_test_handle_joint".
When a sensor is instantiated, if the desired sensor_link_name is not found, the sensor class prints a list of possible names to where the sensor can be attached.
_Remark: Differently from Gazebo, in raisim sensors should be attached to model joints._ 

Most of the changes are aesthetics, the real changes are just a few lines in sensors.h and the shelf odometry link name in Environment.hpp